### PR TITLE
feature: Serializer & SPI

### DIFF
--- a/example-consumer/src/main/java/com/lyf/example/consumer/ConsumerExample.java
+++ b/example-consumer/src/main/java/com/lyf/example/consumer/ConsumerExample.java
@@ -15,7 +15,5 @@ public class ConsumerExample {
     } else {
       System.out.println("User not found");
     }
-    long num = userService.getNumber();
-    System.out.println(num);
   }
 }

--- a/example-consumer/src/main/java/com/lyf/example/consumer/UserServiceProxy.java
+++ b/example-consumer/src/main/java/com/lyf/example/consumer/UserServiceProxy.java
@@ -6,7 +6,7 @@ import com.lyf.example.common.model.User;
 import com.lyf.example.common.service.UserService;
 import com.lyf.model.RpcRequest;
 import com.lyf.model.RpcResponse;
-import com.lyf.serializer.JDKSerializerImpl;
+import com.lyf.serializer.JDKSerializer;
 import com.lyf.serializer.Serializer;
 
 import java.io.IOException;
@@ -14,7 +14,7 @@ import java.io.IOException;
 public class UserServiceProxy implements UserService {
     @Override
     public User getUser(User user) {
-        Serializer serializer = new JDKSerializerImpl();
+        Serializer serializer = new JDKSerializer();
         RpcRequest rpcRequest = RpcRequest.builder()
                 .serviceName(UserService.class.getName())
                 .methodName("getUser")

--- a/example-consumer/src/main/resources/application.properties
+++ b/example-consumer/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 rpc.name=lyf-rpc
 rpc.version=0.1.0
 rpc.port=8081
-rpc.mock=true
+rpc.mock=false
+rpc.serializer=hessian

--- a/example-provider/src/main/resources/application.properties
+++ b/example-provider/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 rpc.name=lyf-rpc
 rpc.version=0.1.0
 rpc.port=8081
-rpc.mock=true
+rpc.mock=false
+rpc.serializer=hessian

--- a/lyf-rpc-core/pom.xml
+++ b/lyf-rpc-core/pom.xml
@@ -9,6 +9,7 @@
     <artifactId>lyf-rpc-core</artifactId>
     <name>lyf-rpc-core</name>
 
+
     <dependencies>
         <dependency>
             <groupId>io.vertx</groupId>
@@ -42,6 +43,24 @@
             <artifactId>junit</artifactId>
             <version>RELEASE</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.caucho</groupId>
+            <artifactId>hessian</artifactId>
+            <version>4.0.66</version>
+        </dependency>
+        <dependency>
+            <groupId>com.esotericsoftware</groupId>
+            <artifactId>kryo</artifactId>
+            <version>5.6.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/lyf-rpc-core/src/main/java/com/lyf/config/RpcConfig.java
+++ b/lyf-rpc-core/src/main/java/com/lyf/config/RpcConfig.java
@@ -1,5 +1,7 @@
 package com.lyf.config;
 
+import com.lyf.serializer.Serializer;
+import com.lyf.serializer.SerializerKeys;
 import lombok.Data;
 
 /**
@@ -13,4 +15,6 @@ public class RpcConfig {
   private Integer port = 8080;
   // mock mode
   private boolean mock = false;
+  // serializer type
+  private String serializer = SerializerKeys.JDK;
 }

--- a/lyf-rpc-core/src/main/java/com/lyf/proxy/ServiceProxy.java
+++ b/lyf-rpc-core/src/main/java/com/lyf/proxy/ServiceProxy.java
@@ -2,10 +2,12 @@ package com.lyf.proxy;
 
 import cn.hutool.http.HttpRequest;
 import cn.hutool.http.HttpResponse;
+import com.lyf.RpcApplication;
 import com.lyf.model.RpcRequest;
 import com.lyf.model.RpcResponse;
-import com.lyf.serializer.JDKSerializerImpl;
+import com.lyf.serializer.JDKSerializer;
 import com.lyf.serializer.Serializer;
+import com.lyf.serializer.SerializerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationHandler;
@@ -15,9 +17,11 @@ import java.lang.reflect.Method;
  * 基于JDK的动态代理
  */
 public class ServiceProxy implements InvocationHandler {
+
+    final Serializer serializer = SerializerFactory.getInstance(RpcApplication.getConfig().getSerializer());
+
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-        Serializer serializer = new JDKSerializerImpl();
         RpcRequest rpcRequest = RpcRequest.builder()
                 .serviceName(method.getDeclaringClass().getName())
                 .methodName(method.getName())
@@ -28,7 +32,7 @@ public class ServiceProxy implements InvocationHandler {
             // 序列化
             byte[] bodyBytes = serializer.serialize(rpcRequest);
             byte[] result;
-            try(HttpResponse httpResponse = HttpRequest.post("http://localhost:8090")
+            try(HttpResponse httpResponse = HttpRequest.post("http://localhost:8081")
                     .body(bodyBytes).execute()) {
                 result = httpResponse.bodyBytes();
             }

--- a/lyf-rpc-core/src/main/java/com/lyf/proxy/ServiceProxy.java
+++ b/lyf-rpc-core/src/main/java/com/lyf/proxy/ServiceProxy.java
@@ -5,7 +5,6 @@ import cn.hutool.http.HttpResponse;
 import com.lyf.RpcApplication;
 import com.lyf.model.RpcRequest;
 import com.lyf.model.RpcResponse;
-import com.lyf.serializer.JDKSerializer;
 import com.lyf.serializer.Serializer;
 import com.lyf.serializer.SerializerFactory;
 

--- a/lyf-rpc-core/src/main/java/com/lyf/proxy/ServiceProxyFactory.java
+++ b/lyf-rpc-core/src/main/java/com/lyf/proxy/ServiceProxyFactory.java
@@ -1,7 +1,6 @@
 package com.lyf.proxy;
 
 import com.lyf.RpcApplication;
-import com.lyf.utils.ConfigUtils;
 
 import java.lang.reflect.Proxy;
 

--- a/lyf-rpc-core/src/main/java/com/lyf/serializer/HessianSerializer.java
+++ b/lyf-rpc-core/src/main/java/com/lyf/serializer/HessianSerializer.java
@@ -1,0 +1,28 @@
+package com.lyf.serializer;
+
+import com.caucho.hessian.io.HessianInput;
+import com.caucho.hessian.io.HessianOutput;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class HessianSerializer implements Serializer{
+  @Override
+  public <T> byte[] serialize(T object) throws IOException {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    HessianOutput hessianOutput = new HessianOutput(outputStream);
+    hessianOutput.writeObject(object);
+    return outputStream.toByteArray();
+  }
+
+  @Override
+  public <T> T deserialize(byte[] bytes, Class<T> type) throws IOException {
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
+    HessianInput hessianInput = new HessianInput(inputStream);
+    if (type != null) {
+      return (T) hessianInput.readObject(type);
+    }
+    return null;
+  }
+}

--- a/lyf-rpc-core/src/main/java/com/lyf/serializer/JDKSerializer.java
+++ b/lyf-rpc-core/src/main/java/com/lyf/serializer/JDKSerializer.java
@@ -5,7 +5,7 @@ import java.io.*;
 /**
  * 基于Java-JDK的序列化 反序列化工具
  */
-public class JDKSerializerImpl implements Serializer{
+public class JDKSerializer implements Serializer{
     @Override
     public <T> byte[] serialize(T object) throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();

--- a/lyf-rpc-core/src/main/java/com/lyf/serializer/JsonSerializer.java
+++ b/lyf-rpc-core/src/main/java/com/lyf/serializer/JsonSerializer.java
@@ -1,0 +1,62 @@
+package com.lyf.serializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lyf.model.RpcRequest;
+import com.lyf.model.RpcResponse;
+
+import java.io.IOException;
+
+public class JsonSerializer implements Serializer{
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @Override
+  public <T> byte[] serialize(T object) throws IOException {
+    return OBJECT_MAPPER.writeValueAsBytes(object);
+  }
+
+  @Override
+  public <T> T deserialize(byte[] bytes, Class<T> type) throws IOException {
+    T obj = OBJECT_MAPPER.readValue(bytes, type);
+    if (obj instanceof RpcRequest) {
+      return handleRequest((RpcRequest) obj, type);
+    }
+    if (obj instanceof RpcResponse) {
+      return handleResponse((RpcResponse) obj, type);
+    }
+    return obj;
+  }
+
+  /**
+   * 根据请求体的参数类型和参数值，将参数值转换成对应的类型
+   * @param rpcRequest
+   * @param type
+   * @return
+   * @param <T>
+   * @throws IOException
+   */
+  private <T> T handleRequest(RpcRequest rpcRequest, Class<T> type) throws IOException {
+    Class<?>[] parametersType = rpcRequest.getParameterTypeList();
+    Object[] args = rpcRequest.getArgs();
+
+    for (int i=0; i< parametersType.length; i++) {
+      Class<?> clazz = parametersType[i];
+      if (!clazz.isAssignableFrom(args[i].getClass())) {
+        byte[] argBytes = OBJECT_MAPPER.writeValueAsBytes(args[i]);
+        args[i] = OBJECT_MAPPER.readValue(argBytes, clazz);
+      }
+    }
+
+    return type.cast(rpcRequest);
+
+  }
+
+  private <T> T handleResponse(RpcResponse rpcResponse, Class<T> type) throws IOException {
+    // 处理响应数据
+    byte[] dataBytes = OBJECT_MAPPER.writeValueAsBytes(rpcResponse.getData());
+    rpcResponse.setData(OBJECT_MAPPER.readValue(dataBytes, type));
+    return type.cast(rpcResponse);
+  }
+
+
+}

--- a/lyf-rpc-core/src/main/java/com/lyf/serializer/KryoSerializer.java
+++ b/lyf-rpc-core/src/main/java/com/lyf/serializer/KryoSerializer.java
@@ -1,0 +1,44 @@
+package com.lyf.serializer;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class KryoSerializer implements Serializer{
+
+  // Kryo线程不安全，需要使用 ThreadLocal保证每个线程只有一个kryo实例
+  private static final ThreadLocal<Kryo> KRYO_THREAD_LOCAL = ThreadLocal.withInitial(
+      () -> {
+        Kryo kryo = new Kryo();
+        // 默认情况下，Kryo是不支持类注册的，所以这里需要关闭
+        kryo.setRegistrationRequired(false);
+        return kryo;
+      }
+  );
+
+  @Override
+  public <T> byte[] serialize(T object) throws IOException {
+    // Object to bytes
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    Output output = new Output(byteArrayOutputStream);
+    KRYO_THREAD_LOCAL.get().writeObject(output, object);
+    output.close();
+
+    return byteArrayOutputStream.toByteArray();
+  }
+
+  @Override
+  public <T> T deserialize(byte[] bytes, Class<T> type) throws IOException {
+    // bytes to object
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+    Input input = new Input(byteArrayInputStream);
+    T object = KRYO_THREAD_LOCAL.get().readObject(input, type);
+    input.close();
+
+    return object;
+  }
+}

--- a/lyf-rpc-core/src/main/java/com/lyf/serializer/SerializerFactory.java
+++ b/lyf-rpc-core/src/main/java/com/lyf/serializer/SerializerFactory.java
@@ -1,0 +1,18 @@
+package com.lyf.serializer;
+
+import com.lyf.spi.SpiLoader;
+
+public class SerializerFactory {
+
+  static {
+    // 确保在使用Factory时，已经加载了Serializer接口的实现类
+    SpiLoader.load(Serializer.class);
+  }
+
+  private static final Serializer DEFAULT_SERIALIZER = new JDKSerializer();
+
+  public static Serializer getInstance(String key) {
+    return SpiLoader.getInstance(Serializer.class, key);
+  }
+
+}

--- a/lyf-rpc-core/src/main/java/com/lyf/serializer/SerializerKeys.java
+++ b/lyf-rpc-core/src/main/java/com/lyf/serializer/SerializerKeys.java
@@ -1,0 +1,10 @@
+package com.lyf.serializer;
+
+public interface SerializerKeys {
+
+  String JDK = "jdk";
+  String JSON = "json";
+  String KRYO = "kryo";
+  String HESSIAN = "hessian";
+
+}

--- a/lyf-rpc-core/src/main/java/com/lyf/server/HttpServerHandler.java
+++ b/lyf-rpc-core/src/main/java/com/lyf/server/HttpServerHandler.java
@@ -4,7 +4,6 @@ import com.lyf.RpcApplication;
 import com.lyf.model.RpcRequest;
 import com.lyf.model.RpcResponse;
 import com.lyf.registry.Registry;
-import com.lyf.serializer.JDKSerializer;
 import com.lyf.serializer.Serializer;
 import com.lyf.serializer.SerializerFactory;
 import io.vertx.core.Handler;

--- a/lyf-rpc-core/src/main/java/com/lyf/spi/SpiLoader.java
+++ b/lyf-rpc-core/src/main/java/com/lyf/spi/SpiLoader.java
@@ -1,0 +1,103 @@
+package com.lyf.spi;
+
+import cn.hutool.core.io.resource.ResourceUtil;
+import com.lyf.serializer.Serializer;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+public class SpiLoader {
+  // interfaceName -> <key, implClass>
+  private static Map<String, Map<String, Class<?>>> loaderMap = new ConcurrentHashMap<>();
+  // cache
+  private static Map<String, Object> instanceCache = new ConcurrentHashMap<>();
+  // System Spi Content
+  private static final String SYSTEM_SPI_CONTENT = "META-INF/rpc/system/";
+  // Custom Spi Content
+  private static final String CUSTOM_SPI_CONTENT = "META-INF/rpc/custom/";
+  // Scan content
+  private static final String[] SCAN_DIRS = new String[]{SYSTEM_SPI_CONTENT, CUSTOM_SPI_CONTENT};
+  // dramatic loading classes list
+  private static final List<Class<?>> LOAD_CLASS_LIST = Arrays.asList(Serializer.class);
+
+  public static void loadAll() {
+    log.info("Loading all the spi for serializer");
+    for (Class<?> clazz : LOAD_CLASS_LIST) {
+      load(clazz);
+    }
+  }
+
+  /**
+   * 加载某个类型
+   * @param loadClass
+   * @return
+   */
+  public static Map<String, Class<?>> load(Class<?> loadClass) {
+    log.info("Loading type of {} SPI", loadClass.getName());
+    Map<String, Class<?>> keyClassMap = new HashMap<>();
+    for (String scanDir : SCAN_DIRS) {
+      List<URL> resources = ResourceUtil.getResources(scanDir + loadClass.getName());
+      // read files in resources
+      for (URL resource : resources) {
+        try {
+          InputStreamReader inputStreamReader = new InputStreamReader(resource.openStream());
+          BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
+          String line;
+          while ((line = bufferedReader.readLine()) != null) {
+            String[] strings = line.split("=");
+            if (strings.length > 1) {
+              String key = strings[0];
+              String className = strings[1];
+              keyClassMap.put(key, Class.forName(className));
+            }
+          }
+        } catch (Exception e) {
+          log.error("load spi error", e);
+        }
+      }
+    }
+
+    loaderMap.put(loadClass.getName(), keyClassMap);
+    return keyClassMap;
+  }
+
+  /**
+   * 根据 key 获取实例
+   * @param clazz
+   * @param key
+   * @return
+   * @param <T>
+   */
+  public static <T> T getInstance(Class<T> clazz, String key) {
+    String clazzName = clazz.getName();
+    Map<String, Class<?>> keyClassMap = loaderMap.get(clazzName);
+    if (keyClassMap == null) {
+      throw new RuntimeException("No spi found for " + clazzName);
+    }
+    if (!keyClassMap.containsKey(key)) {
+      throw new RuntimeException("No spi found for " + clazzName + " with key " + key);
+    }
+    Class<?> implClass = keyClassMap.get(key);
+    if (instanceCache.containsKey(implClass.getName())) {
+      return (T) instanceCache.get(implClass.getName());
+    } else {
+      try {
+        T instance = (T) implClass.newInstance();
+        instanceCache.put(implClass.getName(), instance);
+        return instance;
+      } catch (Exception e) {
+        String errorMsg = "create instance error" + implClass;
+        throw new RuntimeException(errorMsg, e);
+      }
+    }
+  }
+
+}

--- a/lyf-rpc-core/src/main/resources/META-INF/rpc/custom/com.lyf.serializer.Serializer
+++ b/lyf-rpc-core/src/main/resources/META-INF/rpc/custom/com.lyf.serializer.Serializer
@@ -1,0 +1,2 @@
+hessian=com.lyf.serializer.HessianSerializer
+kryo=com.lyf.serializer.KryoSerializer

--- a/lyf-rpc-core/src/main/resources/META-INF/rpc/system/com.lyf.serializer.Serializer
+++ b/lyf-rpc-core/src/main/resources/META-INF/rpc/system/com.lyf.serializer.Serializer
@@ -1,0 +1,1 @@
+jdk=com.lyf.serializer.JDKSerializer

--- a/lyf-rpc-core/src/main/resources/META-INF/services/com.lyf.serializer.Serializer
+++ b/lyf-rpc-core/src/main/resources/META-INF/services/com.lyf.serializer.Serializer
@@ -1,0 +1,1 @@
+com.lyf.serializer.JDKSerializer

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,8 @@
 
   <properties>
     <project.version>1.0.0</project.version>
+    <jackson.version>2.16.1</jackson.version>
+    <slf4j.version>1.7.36</slf4j.version>
   </properties>
 
   <dependencyManagement>
@@ -17,7 +19,17 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.36</version>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${jackson.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
- Different kinds of serializer
- SPI for Serializer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `HessianSerializer`, `KryoSerializer`, and `SerializerFactory` for enhanced serialization options.
  - Added support for different serializers (JDK, JSON, KRYO, HESSIAN) via `SerializerKeys`.

- **Changes**
  - Updated application properties to switch `rpc.mock` from `true` to `false` and added `rpc.serializer=hessian`.
  - Enhanced serialization handling in the `ServiceProxy` and `HttpServerHandler` using `SerializerFactory`.
  - Renamed `JDKSerializerImpl` to `JDKSerializer`.
  - Improved dependency management in `pom.xml` for Jackson and SLF4J.

- **Bug Fixes**
  - Corrected serializer imports and instance handling in various files to ensure proper functionality.

- **Chores**
  - Updated dependencies and managed versions in `pom.xml` for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->